### PR TITLE
Reading and setting goal current + 3mbps baudrate option

### DIFF
--- a/src/components/SettingsComponent.vue
+++ b/src/components/SettingsComponent.vue
@@ -270,7 +270,8 @@ const baudRates = [
   { value: 57600, label: '57600 (Recommended)' },
   { value: 115200, label: '115200' },
   { value: 1000000, label: '1000000' },
-  { value: 2000000, label: '2000000' }
+  { value: 2000000, label: '2000000' },
+  { value: 3000000, label: '3000000' }
 ]
 
 const defaultSettings: Settings = {

--- a/src/main.ts
+++ b/src/main.ts
@@ -274,6 +274,7 @@ ipcMain.handle('dynamixel-start-background-discovery', async (_event, options = 
     }
     
     const { startId = 1, endId = 20 } = options;
+    // const { startId = 100, endId = 120 } = options;
     
     // Signal discovery start
     mainWindow.webContents.send('background-discovery-started', { startId, endId });
@@ -428,6 +429,20 @@ ipcMain.handle('dynamixel-read-motor-status', async (_event, id: number) => {
     return await dynamixelService.readMotorStatus(id);
   } catch (error) {
     log.error('Motor status read failed:', error);
+    throw error;
+  }
+});
+
+ipcMain.handle('dynamixel-set-motor-goal-current', async (_event, id: number, goalCurrent: number) => {
+  try {
+    if (!dynamixelService) {
+      log.error('DYNAMIXEL service not initialized');
+      throw new Error('DYNAMIXEL service not initialized');
+    }
+    await dynamixelService.setMotorGoalCurrent(id, goalCurrent);
+    return true;
+  } catch (error) {
+    log.error('Motor set goal current failed:', error);
     throw error;
   }
 });

--- a/src/preload.ts
+++ b/src/preload.ts
@@ -44,6 +44,7 @@ contextBridge.exposeInMainWorld('dynamixelAPI', {
   controlLED: (id: number, ledOn: boolean) => ipcRenderer.invoke('dynamixel-control-led', id, ledOn),
   pingMotor: (id: number) => ipcRenderer.invoke('dynamixel-ping-motor', id),
   readMotorStatus: (id: number) => ipcRenderer.invoke('dynamixel-read-motor-status', id),
+  setMotorGoalCurrent: (id: number, goalCurrent: number) => ipcRenderer.invoke('dynamixel-set-motor-goal-current', id, goalCurrent),
   moveMotorToPosition: (id: number, position: number) => ipcRenderer.invoke('dynamixel-move-motor-to-position', id, position),
   emergencyStop: (id: number) => ipcRenderer.invoke('dynamixel-emergency-stop', id),
   enableTorqueForAllMotors: () => ipcRenderer.invoke('dynamixel-enable-torque-all'),


### PR DESCRIPTION
Reading+setting goal current requires proposed changes made in `node-dynamixel`,

The actual method to set goal current is pretty barebones (`src/services/dynamixel-controller.ts`:`setMotorGoalCurrent`, L740-744) compared to the existing `moveMotorToPosition` example (L746+).

I added 3mbps baudrate in `src/components/SettingsComponent.vue` because that's my preferred baudrate, all options should probably be added here at some point.